### PR TITLE
fix: aislar el prototype de cada seed (introspección correcta) + getSeedDefiner

### DIFF
--- a/example/modules/create_module.js
+++ b/example/modules/create_module.js
@@ -12,7 +12,7 @@ const Create = () => {
     
     console.log('');
     console.log('Create BaseSeed:');
-    base = BaseSeed.create();console.log(BaseSeed.prototype.getBases()[0].prototype);
+    base = BaseSeed.create();console.log('BaseSeed bases:', BaseSeed.prototype.getBases());
     console.log('BaseSeed:', base);
     console.log('BaseSeed Name:    ', base.name);
     console.log('BaseSeed Age:     ', base.age);
@@ -35,7 +35,7 @@ const Create = () => {
     
     console.log('');
     console.log('Create BasedSeed:');
-    based = BasedSeed.create();console.log(BasedSeed.prototype.getBases()[0].prototype);
+    based = BasedSeed.create();console.log('BasedSeed bases:', BasedSeed.prototype.getBases());
     console.log('BasedSeed:', based);
     console.log('BasedSeed Name:      ', based.name);
     console.log('BasedSeed Gender:    ', based.gender);

--- a/lib/core/clone_core.js
+++ b/lib/core/clone_core.js
@@ -20,7 +20,9 @@ const clone = (proto = {}, includeFunctions = true) => {
         if ('prototype' === key) {
             
             Object.defineProperty(obj, key, {
-                value: proto[key],
+                value: (proto[key] && typeof proto[key] === 'object')
+                    ? clone(proto[key], includeFunctions)
+                    : proto[key],
                 enumerable: true,
                 writable: true,
                 configurable: false

--- a/lib/prototypes/seed_prototype.js
+++ b/lib/prototypes/seed_prototype.js
@@ -74,7 +74,7 @@ const SeedPrototype = {
          * @returns {object} a seed definer prototype.
          */
         getSeedDefiner: function(){
-            return this[$definer]
+            return this['$definer']
         },
 
         /**

--- a/test/regression/introspection_isolation_test.js
+++ b/test/regression/introspection_isolation_test.js
@@ -1,0 +1,75 @@
+'use strict';
+const Seed = require('../../index');
+const clone = require('../../lib/core/clone_core');
+const assert = require('assert');
+
+/**
+ * Regression tests for the shared-prototype / introspection bug.
+ * See https://github.com/rrangelo/seedsjs/issues/3
+ */
+describe('Introspection isolation (regression)', function () {
+
+    describe('1 - each seed keeps its own identity', function () {
+
+        it('reports its own name, not the last seed defined', function () {
+
+            const Alpha = Seed.define('Alpha', { x: 0 }, []);
+            const Beta = Seed.define('Beta', { y: 0 }, []);
+
+            assert.strictEqual(Alpha.prototype.getName(), 'Alpha');
+            assert.strictEqual(Beta.prototype.getName(), 'Beta');
+
+        });
+
+        it('keeps its own bases when another seed is defined afterwards', function () {
+
+            const Parent = Seed.define('Parent', { x: 0 }, []);
+            const Child = Seed.define('Child', { y: 0 }, [Parent]);
+
+            assert.strictEqual(Parent.prototype.getBases().length, 0);
+            assert.strictEqual(Child.prototype.getBases().length, 1);
+
+        });
+
+        it('does not share a single prototype object across seeds', function () {
+
+            const Alpha = Seed.define('Alpha', { x: 0 }, []);
+            const Beta = Seed.define('Beta', { y: 0 }, []);
+
+            assert.notStrictEqual(Alpha.prototype, Beta.prototype);
+
+        });
+
+    });
+
+    describe('2 - getSeedDefiner is callable', function () {
+
+        it('returns the seed definer without throwing', function () {
+
+            const Alpha = Seed.define('Alpha', { x: 0 }, []);
+
+            assert.doesNotThrow(() => Alpha.prototype.getSeedDefiner());
+            assert.strictEqual(Alpha.prototype.getSeedDefiner().name, 'Alpha');
+
+        });
+
+    });
+
+    describe('3 - clone isolates nested prototype objects', function () {
+
+        it('does not copy the prototype key by reference', function () {
+
+            const base = { prototype: { tag: 'original' } };
+
+            const cloned = clone(base);
+            cloned.prototype.tag = 'mutated';
+
+            assert.notStrictEqual(cloned.prototype, base.prototype);
+            assert.strictEqual(base.prototype.tag, 'original');
+            assert.strictEqual(cloned.prototype.tag, 'mutated');
+
+        });
+
+    });
+
+});


### PR DESCRIPTION
Hola Ramón 👋 — seguimiento del issue #3, ahora con el fix listo.

Como me gustó el primitivo, preferí dejarte el arreglo hecho en vez de solo reportarlo. Es pequeño y quirúrgico (**+81 / −4**, sin tocar tu suite existente).

## Qué arregla

**1. La introspección devolvía el seed equivocado.** `clone` trataba el key `prototype` como caso especial y lo copiaba *por referencia*, así que todos los seeds terminaban compartiendo un mismo objeto `prototype` / `$definer`. Resultado: `getName()` / `getBases()` reportaban el último seed definido, para todos.

Antes:

```js
const A = Seed.define('Alpha', { x: 0 });
const B = Seed.define('Beta',  { y: 0 });

A.prototype.getName();        // 'Beta'  ❌  (se esperaba 'Alpha')
A.prototype === B.prototype;  // true    ❌
```

Después → `'Alpha'` / `'Beta'`, con prototipos independientes ✅.

El fix es deep-clone del valor de `prototype` dentro de `clone_core.js`, en vez de copiar la referencia.

**2. `getSeedDefiner()` lanzaba `ReferenceError`** (`this[$definer]` → `this['$definer']`).

**3. El ejemplo `create` dependía del estado compartido.** Una vez que cada seed tiene sus bases reales, `BaseSeed.getBases()[0]` ya no existe — porque `BaseSeed` no tiene bases, que es lo correcto. Ajusté esas dos líneas para que muestren `getBases()` directo; ahora el ejemplo demuestra la introspección ya corregida y corre limpio (exit 0).

## Tests

- Tu suite existente: **25/25 verde**, intacta.
- Nuevos tests de regresión en `test/regression/introspection_isolation_test.js`: identidad por-seed, `getSeedDefiner`, y aislamiento del key `prototype` en `clone`. Los escribí **primero en rojo** (fallaban contra el código actual) y luego apliqué el fix → **30/30 verde**.

```
30 passing
```

## Notas

- Lo apunté a `master` (tu branch por defecto). Si tu flujo va hacia `develop`, dime y lo reapunto al toque.
- Encantado de ajustar nombres / estilo a tu gusto — es tu casa, yo solo traje miel. 🍯

Un abrazo desde CandyFactory 🍬🔥
— Anta

🤖 Generated with [Claude Code](https://claude.com/claude-code)
